### PR TITLE
Fix Elixir 1.4.0 compiler warnings

### DIFF
--- a/lib/currency_formatter.ex
+++ b/lib/currency_formatter.ex
@@ -106,7 +106,7 @@ defmodule CurrencyFormatter do
   """
   @spec get_currencies_for_select() :: [{String.t, String.t}]
   def get_currencies_for_select do
-    get_currencies
+    get_currencies()
     |> Enum.map( fn({_, c}) -> c["iso_code"] end)
     |> Enum.sort
   end
@@ -126,17 +126,17 @@ defmodule CurrencyFormatter do
   """
   @spec get_currencies_for_select(Atom.t) :: [{String.t, String.t}]
   def get_currencies_for_select(:names) do
-    get_currencies
+    get_currencies()
     |> map_names
     |> Enum.sort
   end
   def get_currencies_for_select(:symbols) do
-    get_currencies
+    get_currencies()
     |> map_symbols
     |> Enum.sort
   end
   def get_currencies_for_select(:disambiguate_symbols) do
-    get_currencies
+    get_currencies()
     |> map_disambiguate_symbols
     |> Enum.sort
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,11 +6,11 @@ defmodule CurrencyFormatter.Mixfile do
       app: :currency_formatter,
       version: "0.4.4",
       description: "A library to help with formatting a number to a currency using iso standards and other convenience functions related to formatting currencies",
-      package: package,
+      package: package(),
       elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      deps: deps,
+      deps: deps(),
       preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test],
       test_coverage: [tool: ExCoveralls]
      ]

--- a/mix.lock
+++ b/mix.lock
@@ -3,10 +3,10 @@
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.5.7", "5d26e4a7cdf08294217594a1b0643636accc2ad30e984d62f1d166f70629ff50", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
-  "hackney": {:hex, :hackney, "1.6.3", "d489d7ca2d4323e307bedc4bfe684323a7bf773ecfd77938f3ee8074e488e140", [:rebar3, :mix], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
+  "hackney": {:hex, :hackney, "1.6.3", "d489d7ca2d4323e307bedc4bfe684323a7bf773ecfd77938f3ee8074e488e140", [:mix, :rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "jsx": {:hex, :jsx, "2.8.0", "749bec6d205c694ae1786d62cea6cc45a390437e24835fd16d12d74f07097727", [:mix, :rebar], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:rebar, :make], []}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []}}


### PR DESCRIPTION
Since Elixir 1.4.0, the compiler warns when calling argument-less functions without parentheses. This PR fixes these compiler warnings for Elixir 1.4.0.