### PR TITLE
Support excluding currencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,19 @@ end
 ```
 
 ## Setup
-By default you will have 172 currencies available, if you would like to limit the list you can configure a whitelist in your app's config.exs like :
+By default you will have 172 currencies available, there are two configuration options that can be set in your app's `config.exs` file to limit the number of currencies.
+
+If you would like to limit the list to only include specific currencies, you can configure a whitelist by passing a list of ISO codes to include:
+
 ```elixir
 config :currency_formatter, :whitelist, ["EUR", "GBP", "USD"]
 ```
 
+To exclude certain currencies from the list, you can configure a blacklist using a list of ISO codes to exclude:
+
+```elixir
+config :currency_formatter, :blacklist, ["XDR", "XAG", "XAU"]
+```
 
 ## Documentation
 

--- a/lib/currency_formatter.ex
+++ b/lib/currency_formatter.ex
@@ -84,16 +84,23 @@ defmodule CurrencyFormatter do
   """
   @spec get_currencies() :: Map.t
   def get_currencies do
-    @currencies |> whitelist
+    @currencies 
+    |> whitelist(Application.get_env(:currency_formatter, :whitelist))
+    |> blacklist(Application.get_env(:currency_formatter, :blacklist))
   end
 
-  defp whitelist(currencies) do
-    whitelist = Application.get_env(:currency_formatter, :whitelist)
-    if whitelist == nil do
-      currencies
-    else
-      Enum.filter(currencies, fn {_, %{"iso_code" => iso_code}} -> Enum.member?(whitelist, iso_code) end)
-    end
+  defp whitelist(currencies, nil), do: currencies
+  defp whitelist(currencies, whitelist) do
+    Map.take(currencies, downcase(whitelist))
+  end
+
+  defp blacklist(currencies, nil), do: currencies
+  defp blacklist(currencies, blacklist) do
+    Map.drop(currencies, downcase(blacklist))
+  end
+
+  defp downcase(list) when is_list(list) do
+    list |> Enum.map(fn(val) -> String.downcase(val) end)
   end
 
   @doc """

--- a/mix.lock
+++ b/mix.lock
@@ -2,11 +2,11 @@
   "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.6.3", "894bf9254890a4aac1d1165da08145a72700ff42d8cb6ce8195a584cb2a4b374", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
-  "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
+  "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
   "hackney": {:hex, :hackney, "1.7.1", "e238c52c5df3c3b16ce613d3a51c7220a784d734879b1e231c9babd433ac1cb4", [:rebar3], [{:certifi, "1.0.0", [hex: :certifi, optional: false]}, {:idna, "4.0.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "4.0.0", "10aaa9f79d0b12cf0def53038547855b91144f1bfcc0ec73494f38bb7b9c4961", [:rebar3], []},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], []},
-  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [], []},
-  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [], []},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [], []}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []}}


### PR DESCRIPTION
Allow users to exclude specified currency types.

Updated the whitelist (include only) and blacklist (exclude) functions
to return a uniform Map interface.  Previously whitelisting returned a
list instead of a Map, which differed from the return value of when
whitelisting was not included.