### PR TITLE
Use the symbol by default when formatting

### DIFF
--- a/lib/currency_formatter.ex
+++ b/lib/currency_formatter.ex
@@ -210,6 +210,9 @@ defmodule CurrencyFormatter do
     |> Enum.reverse
     |> set_separators(format["thousands_separator"], "")
   end
+  defp set_separators([a, b, c, ?- | tail], separator, acc) do
+    set_separators([?- | tail], separator, [c, b, a | acc])
+  end
   defp set_separators([a, b, c, d | tail], separator, acc) do
     set_separators([d | tail], separator, [separator, c, b, a | acc])
   end

--- a/test/currency_formatter_test.exs
+++ b/test/currency_formatter_test.exs
@@ -20,7 +20,7 @@ defmodule CurrencyFormatterTest do
     assert "A$0.01" = CurrencyFormatter.format(1, :AUD)
   end
 
-  test "should format an amount_in_cents as integer to a price in euro" do
+  test "should format an amount_in_cents as integer to a price in dollars" do
     assert "US$0.01" = CurrencyFormatter.format(1)
     assert "US$0.12" = CurrencyFormatter.format(12)
     assert "US$1.23" = CurrencyFormatter.format(123)
@@ -34,10 +34,12 @@ defmodule CurrencyFormatterTest do
     assert "US$123,456.78" = CurrencyFormatter.format(12345678)
     assert "US$1,234,567.89" = CurrencyFormatter.format(123456789)
     assert "US$12,345,678.90" = CurrencyFormatter.format(1234567890)
+    assert "US$-113,728" = CurrencyFormatter.format(-11372800)
+    assert "US$-499" = CurrencyFormatter.format(-49900)
     assert "US$1" = CurrencyFormatter.format(100)
   end
 
-  test "should format an amount_in_cents as integer to a price in dollars" do
+  test "should format an amount_in_cents as integer to a price in euros" do
     assert "€0,01" = CurrencyFormatter.format(1, :eur)
     assert "€0,12" = CurrencyFormatter.format(12, :eur)
     assert "€1,23" = CurrencyFormatter.format(123, :eur)
@@ -51,6 +53,8 @@ defmodule CurrencyFormatterTest do
     assert "€123.456,78" = CurrencyFormatter.format(12345678, :eur)
     assert "€1.234.567,89" = CurrencyFormatter.format(123456789, :eur)
     assert "€12.345.678,90" = CurrencyFormatter.format(1234567890, :eur)
+    assert "€-113.728" = CurrencyFormatter.format(-11372800, :eur)
+    assert "€-499" = CurrencyFormatter.format(-49900, :eur)
     assert "€1" = CurrencyFormatter.format(100, :eur)
   end
 

--- a/test/currency_formatter_test.exs
+++ b/test/currency_formatter_test.exs
@@ -14,66 +14,66 @@ defmodule CurrencyFormatterTest do
   end
 
   test "should correctly format in euro and dollars" do
-    assert "€0,01" = CurrencyFormatter.format(1, :eur)
-    assert "US$0.01" = CurrencyFormatter.format(1, "USD")
-    assert "0,01Ft" = CurrencyFormatter.format(1, "huf")
-    assert "A$0.01" = CurrencyFormatter.format(1, :AUD)
+    assert "€0,01" == CurrencyFormatter.format(1, :eur)
+    assert "US$0.01" == CurrencyFormatter.format(1, "USD")
+    assert "0,01Ft" == CurrencyFormatter.format(1, "huf")
+    assert "A$0.01" == CurrencyFormatter.format(1, :AUD)
   end
 
   test "should format an amount_in_cents as integer to a price in dollars" do
-    assert "US$0.01" = CurrencyFormatter.format(1)
-    assert "US$0.12" = CurrencyFormatter.format(12)
-    assert "US$1.23" = CurrencyFormatter.format(123)
-    assert "US$12.34" = CurrencyFormatter.format(1234)
-    assert "US$123.45" = CurrencyFormatter.format(12345)
-    assert "US$1,234.56" = CurrencyFormatter.format(123456)
-    assert "US$1,000" = CurrencyFormatter.format(100000)
-    assert "US$-1,000" = CurrencyFormatter.format(-100000)
-    assert "US$12,345.67" = CurrencyFormatter.format(1234567)
-    assert "US$-12,345.67" = CurrencyFormatter.format(-1234567)
-    assert "US$123,456.78" = CurrencyFormatter.format(12345678)
-    assert "US$1,234,567.89" = CurrencyFormatter.format(123456789)
-    assert "US$12,345,678.90" = CurrencyFormatter.format(1234567890)
-    assert "US$-113,728" = CurrencyFormatter.format(-11372800)
-    assert "US$-499" = CurrencyFormatter.format(-49900)
-    assert "US$1" = CurrencyFormatter.format(100)
+    assert "US$0.01" == CurrencyFormatter.format(1)
+    assert "US$0.12" == CurrencyFormatter.format(12)
+    assert "US$1.23" == CurrencyFormatter.format(123)
+    assert "US$12.34" == CurrencyFormatter.format(1234)
+    assert "US$123.45" == CurrencyFormatter.format(12345)
+    assert "US$1,234.56" == CurrencyFormatter.format(123456)
+    assert "US$1,000" == CurrencyFormatter.format(100000)
+    assert "US$-1,000" == CurrencyFormatter.format(-100000)
+    assert "US$12,345.67" == CurrencyFormatter.format(1234567)
+    assert "US$-12,345.67" == CurrencyFormatter.format(-1234567)
+    assert "US$123,456.78" == CurrencyFormatter.format(12345678)
+    assert "US$1,234,567.89" == CurrencyFormatter.format(123456789)
+    assert "US$12,345,678.90" == CurrencyFormatter.format(1234567890)
+    assert "US$-113,728" == CurrencyFormatter.format(-11372800)
+    assert "US$-499" == CurrencyFormatter.format(-49900)
+    assert "US$1" == CurrencyFormatter.format(100)
   end
 
   test "should format an amount_in_cents as integer to a price in euros" do
-    assert "€0,01" = CurrencyFormatter.format(1, :eur)
-    assert "€0,12" = CurrencyFormatter.format(12, :eur)
-    assert "€1,23" = CurrencyFormatter.format(123, :eur)
-    assert "€12,34" = CurrencyFormatter.format(1234, :eur)
-    assert "€123,45" = CurrencyFormatter.format(12345, :eur)
-    assert "€1.234,56" = CurrencyFormatter.format(123456, :eur)
-    assert "€1.000" = CurrencyFormatter.format(100000, :eur)
-    assert "€-1.000" = CurrencyFormatter.format(-100000, :eur)
-    assert "€12.345,67" = CurrencyFormatter.format(1234567, :eur)
-    assert "€-12.345,67" = CurrencyFormatter.format(-1234567, :eur)
-    assert "€123.456,78" = CurrencyFormatter.format(12345678, :eur)
-    assert "€1.234.567,89" = CurrencyFormatter.format(123456789, :eur)
-    assert "€12.345.678,90" = CurrencyFormatter.format(1234567890, :eur)
-    assert "€-113.728" = CurrencyFormatter.format(-11372800, :eur)
-    assert "€-499" = CurrencyFormatter.format(-49900, :eur)
-    assert "€1" = CurrencyFormatter.format(100, :eur)
+    assert "€0,01" == CurrencyFormatter.format(1, :eur)
+    assert "€0,12" == CurrencyFormatter.format(12, :eur)
+    assert "€1,23" == CurrencyFormatter.format(123, :eur)
+    assert "€12,34" == CurrencyFormatter.format(1234, :eur)
+    assert "€123,45" == CurrencyFormatter.format(12345, :eur)
+    assert "€1.234,56" == CurrencyFormatter.format(123456, :eur)
+    assert "€1.000" == CurrencyFormatter.format(100000, :eur)
+    assert "€-1.000" == CurrencyFormatter.format(-100000, :eur)
+    assert "€12.345,67" == CurrencyFormatter.format(1234567, :eur)
+    assert "€-12.345,67" == CurrencyFormatter.format(-1234567, :eur)
+    assert "€123.456,78" == CurrencyFormatter.format(12345678, :eur)
+    assert "€1.234.567,89" == CurrencyFormatter.format(123456789, :eur)
+    assert "€12.345.678,90" == CurrencyFormatter.format(1234567890, :eur)
+    assert "€-113.728" == CurrencyFormatter.format(-11372800, :eur)
+    assert "€-499" == CurrencyFormatter.format(-49900, :eur)
+    assert "€1" == CurrencyFormatter.format(100, :eur)
   end
 
   test "should format an amount_in_cents as string to a price" do
-    assert "US$0.01" = CurrencyFormatter.format("1")
-    assert "US$0.12" = CurrencyFormatter.format("12")
-    assert "US$1.23" = CurrencyFormatter.format("12.3")
-    assert "US$12.34" = CurrencyFormatter.format("12.34")
-    assert "US$123.45" = CurrencyFormatter.format("123,45")
-    assert "US$1,234.56" = CurrencyFormatter.format("1234,56")
-    assert "US$12,345.67" = CurrencyFormatter.format("12345.67")
-    assert "US$123,456.78" = CurrencyFormatter.format("123456,78")
-    assert "US$1,234,567.89" = CurrencyFormatter.format("1234567.89")
-    assert "US$12,345,678.90" = CurrencyFormatter.format("12345678,90")
-    assert "US$1" = CurrencyFormatter.format("1.00")
+    assert "US$0.01" == CurrencyFormatter.format("1")
+    assert "US$0.12" == CurrencyFormatter.format("12")
+    assert "US$1.23" == CurrencyFormatter.format("12.3")
+    assert "US$12.34" == CurrencyFormatter.format("12.34")
+    assert "US$123.45" == CurrencyFormatter.format("123,45")
+    assert "US$1,234.56" == CurrencyFormatter.format("1234,56")
+    assert "US$12,345.67" == CurrencyFormatter.format("12345.67")
+    assert "US$123,456.78" == CurrencyFormatter.format("123456,78")
+    assert "US$1,234,567.89" == CurrencyFormatter.format("1234567.89")
+    assert "US$12,345,678.90" == CurrencyFormatter.format("12345678,90")
+    assert "US$1" == CurrencyFormatter.format("1.00")
   end
 
   test "should use a currency symbol when given" do
-    assert "US$1,234,567.89" = CurrencyFormatter.format(123456789, :USD)
+    assert "US$1,234,567.89" == CurrencyFormatter.format(123456789, :USD)
   end
 
   test "should return a map with formatting instructions" do
@@ -106,11 +106,11 @@ defmodule CurrencyFormatterTest do
   end
 
   test "should return a list usable for select dropdowns using currency symbols" do
-    assert {"AUD", "$"} = CurrencyFormatter.get_currencies_for_select(:symbols) |> Enum.find( fn({iso, _}) -> iso == "AUD" end)
+    assert {"AUD", "$"} == CurrencyFormatter.get_currencies_for_select(:symbols) |> Enum.find( fn({iso, _}) -> iso == "AUD" end)
   end
 
   test "should return a list usable for select dropdowns using disambiguate currency symbols" do
-    assert {"AUD", "A$"} = CurrencyFormatter.get_currencies_for_select(:disambiguate_symbols) |> Enum.find( fn({iso, _}) -> iso == "AUD" end)
+    assert {"AUD", "A$"} == CurrencyFormatter.get_currencies_for_select(:disambiguate_symbols) |> Enum.find( fn({iso, _}) -> iso == "AUD" end)
   end
 
   test "should raise an error" do
@@ -125,14 +125,14 @@ defmodule CurrencyFormatterTest do
   test "get_currencies should return all currencies except blacklisted currencies" do
     blacklist = ["XDR", "XAG", "XAU"]
     Application.put_env(:currency_formatter, :blacklist,  blacklist)
-    
+
     currencies = CurrencyFormatter.get_currencies()
     [] = currencies |> Enum.filter(fn {_, %{"iso_code" => iso_code}} -> Enum.member?(blacklist, iso_code) end)
-    
-    blacklist |> Enum.each(fn(code) -> 
-      assert Map.get(currencies, String.downcase(code)) == nil 
+
+    blacklist |> Enum.each(fn(code) ->
+      assert Map.get(currencies, String.downcase(code)) == nil
     end)
-    
+
   end
 end
 

--- a/test/currency_formatter_test.exs
+++ b/test/currency_formatter_test.exs
@@ -15,28 +15,28 @@ defmodule CurrencyFormatterTest do
 
   test "should correctly format in euro and dollars" do
     assert "€0,01" == CurrencyFormatter.format(1, :eur)
-    assert "US$0.01" == CurrencyFormatter.format(1, "USD")
+    assert "$0.01" == CurrencyFormatter.format(1, "USD")
     assert "0,01Ft" == CurrencyFormatter.format(1, "huf")
-    assert "A$0.01" == CurrencyFormatter.format(1, :AUD)
+    assert "$0.01" == CurrencyFormatter.format(1, :AUD)
   end
 
   test "should format an amount_in_cents as integer to a price in dollars" do
-    assert "US$0.01" == CurrencyFormatter.format(1)
-    assert "US$0.12" == CurrencyFormatter.format(12)
-    assert "US$1.23" == CurrencyFormatter.format(123)
-    assert "US$12.34" == CurrencyFormatter.format(1234)
-    assert "US$123.45" == CurrencyFormatter.format(12345)
-    assert "US$1,234.56" == CurrencyFormatter.format(123456)
-    assert "US$1,000" == CurrencyFormatter.format(100000)
-    assert "US$-1,000" == CurrencyFormatter.format(-100000)
-    assert "US$12,345.67" == CurrencyFormatter.format(1234567)
-    assert "US$-12,345.67" == CurrencyFormatter.format(-1234567)
-    assert "US$123,456.78" == CurrencyFormatter.format(12345678)
-    assert "US$1,234,567.89" == CurrencyFormatter.format(123456789)
-    assert "US$12,345,678.90" == CurrencyFormatter.format(1234567890)
-    assert "US$-113,728" == CurrencyFormatter.format(-11372800)
-    assert "US$-499" == CurrencyFormatter.format(-49900)
-    assert "US$1" == CurrencyFormatter.format(100)
+    assert "$0.01" == CurrencyFormatter.format(1, :usd)
+    assert "$0.12" == CurrencyFormatter.format(12, :usd)
+    assert "$1.23" == CurrencyFormatter.format(123, :usd)
+    assert "$12.34" == CurrencyFormatter.format(1234, :usd)
+    assert "$123.45" == CurrencyFormatter.format(12345, :usd)
+    assert "$1,234.56" == CurrencyFormatter.format(123456, :usd)
+    assert "$1,000" == CurrencyFormatter.format(100000, :usd)
+    assert "$-1,000" == CurrencyFormatter.format(-100000, :usd)
+    assert "$12,345.67" == CurrencyFormatter.format(1234567, :usd)
+    assert "$-12,345.67" == CurrencyFormatter.format(-1234567, :usd)
+    assert "$123,456.78" == CurrencyFormatter.format(12345678, :usd)
+    assert "$1,234,567.89" == CurrencyFormatter.format(123456789, :usd)
+    assert "$12,345,678.90" == CurrencyFormatter.format(1234567890, :usd)
+    assert "$-113,728" == CurrencyFormatter.format(-11372800, :usd)
+    assert "$-499" == CurrencyFormatter.format(-49900, :usd)
+    assert "$1" == CurrencyFormatter.format(100, :usd)
   end
 
   test "should format an amount_in_cents as integer to a price in euros" do
@@ -59,21 +59,29 @@ defmodule CurrencyFormatterTest do
   end
 
   test "should format an amount_in_cents as string to a price" do
-    assert "US$0.01" == CurrencyFormatter.format("1")
-    assert "US$0.12" == CurrencyFormatter.format("12")
-    assert "US$1.23" == CurrencyFormatter.format("12.3")
-    assert "US$12.34" == CurrencyFormatter.format("12.34")
-    assert "US$123.45" == CurrencyFormatter.format("123,45")
-    assert "US$1,234.56" == CurrencyFormatter.format("1234,56")
-    assert "US$12,345.67" == CurrencyFormatter.format("12345.67")
-    assert "US$123,456.78" == CurrencyFormatter.format("123456,78")
-    assert "US$1,234,567.89" == CurrencyFormatter.format("1234567.89")
-    assert "US$12,345,678.90" == CurrencyFormatter.format("12345678,90")
-    assert "US$1" == CurrencyFormatter.format("1.00")
+    assert "$0.01" == CurrencyFormatter.format("1", :usd)
+    assert "$0.12" == CurrencyFormatter.format("12", :usd)
+    assert "$1.23" == CurrencyFormatter.format("12.3", :usd)
+    assert "$12.34" == CurrencyFormatter.format("12.34", :usd)
+    assert "$123.45" == CurrencyFormatter.format("123,45", :usd)
+    assert "$1,234.56" == CurrencyFormatter.format("1234,56", :usd)
+    assert "$12,345.67" == CurrencyFormatter.format("12345.67", :usd)
+    assert "$123,456.78" == CurrencyFormatter.format("123456,78", :usd)
+    assert "$1,234,567.89" == CurrencyFormatter.format("1234567.89", :usd)
+    assert "$12,345,678.90" == CurrencyFormatter.format("12345678,90", :usd)
+    assert "$1" == CurrencyFormatter.format("1.00", :usd)
   end
 
   test "should use a currency symbol when given" do
-    assert "US$1,234,567.89" == CurrencyFormatter.format(123456789, :USD)
+    assert "$1,234,567.89" == CurrencyFormatter.format(123456789, :USD)
+  end
+
+  test "should allow the ability to disambiguate the currency symbol" do
+    assert "US$12.34" == CurrencyFormatter.format(1234, :usd, disambiguate: true)
+    assert "C$12.34" == CurrencyFormatter.format(1234, :cad, disambiguate: true)
+
+    assert "$12.34" == CurrencyFormatter.format(1234, :usd, disambiguate: false)
+    assert "$12.34" == CurrencyFormatter.format(1234, :cad, disambiguate: false)
   end
 
   test "should return a map with formatting instructions" do
@@ -102,7 +110,15 @@ defmodule CurrencyFormatterTest do
   end
 
   test "symbol" do
-    assert "A$" = CurrencyFormatter.symbol(:AUD)
+    assert "$" == CurrencyFormatter.symbol(:AUD)
+  end
+
+  test "disambiguous_symbol" do
+    assert "A$" == CurrencyFormatter.disambiguous_symbol(:AUD)
+  end
+
+  test "disambiguous_symbol default to symbol if the currency doesn't have a disambiguate_symbol" do
+    assert "դր." == CurrencyFormatter.disambiguous_symbol(:amd)
   end
 
   test "should return a list usable for select dropdowns using currency symbols" do
@@ -132,7 +148,6 @@ defmodule CurrencyFormatterTest do
     blacklist |> Enum.each(fn(code) ->
       assert Map.get(currencies, String.downcase(code)) == nil
     end)
-
   end
 end
 


### PR DESCRIPTION
Rather than the disambiguous_symbol.

Allow an option to disambiguate.