### PR TITLE
Fix to work with more recent versions of phoenix_html

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ iex> CurrencyFormatter.format(654300, :eur)
 iex> CurrencyFormatter.format(654300, :eur, keep_decimals: true)
 "€6.543,00"
 
+iex> CurrencyFormatter.format(1, "huf")
+"0,01Ft"
 
 iex> CurrencyFormatter.format(123456)
 "$1,234.56"
@@ -34,39 +36,19 @@ iex> CurrencyFormatter.format(654321, "AUD", disambiguate: true)
 
 Formatting cents to a currency raw html string
 ```elixir
-      iex> CurrencyFormatter.raw_html_format(123456, "EUR")
-      ~s[<span class="currency-formatter-symbol">€</span><span class="currency-formatter-amount">1.234,56</span>]
-  """
+iex> CurrencyFormatter.raw_html_format(123456, "EUR")
+     ~s[<span class="currency-formatter-symbol">€</span><span class="currency-formatter-amount">1.234,56</span>]
 ```
 
 Formatting cents to a currency safe(phoenix) html string
 
 ```elixir
 iex> CurrencyFormatter.html_format(123456, "EUR")
-      [
-        safe: [
-          60,
-          "span",
-          [[32, "class", 61, 34, "currency-formatter-symbol", 34]],
-          62,
-          "€",
-          60,
-          47,
-          "span",
-          62
-        ],
-        safe: [
-          60,
-          "span",
-          [[32, "class", 61, 34, "currency-formatter-amount", 34]],
-          62,
-          "1.234,56",
-          60,
-          47,
-          "span",
-          62
-        ]
-      ]
+     {:safe,
+       [60, "span", 32, "class", 61, 34, "currency-formatter-symbol", 34,
+        62, "€", 60, 47, "span", 62, 60, "span", 32, "class", 61, 34,
+        "currency-formatter-amount", 34, 62, "1.234,56", 60, 47, "span",
+       62]}
 ```
 
 Requesting formatting instructions for a currency
@@ -126,7 +108,7 @@ As this is [available in Hex](https://hex.pm/docs/publish), the package can be i
 
 ```elixir
 def deps do
-  [{:currency_formatter, "~> 0.4"}]
+  [{:currency_formatter, "~> 0.9.0"}]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule CurrencyFormatter.Mixfile do
   def project do
     [
       app: :currency_formatter,
-      version: "0.8.1",
+      version: "0.9.0",
       description: "A library to help with formatting a number to a currency using iso standards and other convenience functions related to formatting currencies",
       package: package(),
       elixir: "~> 1.7",
@@ -43,7 +43,7 @@ defmodule CurrencyFormatter.Mixfile do
       {:earmark, ">= 0.0.0", only: :dev},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:excoveralls, ">= 0.0.0", only: :test},
-      {:phoenix_html, ">= 0.0.0"},
+      {:phoenix_html, ">= 2.12.0"},
       {:poison, "~> 3.1.0"},
     ]
   end

--- a/test/currency_formatter_test.exs
+++ b/test/currency_formatter_test.exs
@@ -226,4 +226,9 @@ defmodule CurrencyFormatterTest do
       assert Map.get(currencies, String.downcase(code)) == nil
     end)
   end
+
+  test "can convert to html string" do
+    assert "<span class=\"currency-formatter-symbol\">€</span><span class=\"currency-formatter-amount\">0,01</span>" == CurrencyFormatter.html_format(1, :eur) |> Phoenix.HTML.safe_to_string()
+    assert "<span class=\"currency-formatter-amount\">1</span><span class=\"currency-formatter-symbol\">د.إ</span>" == CurrencyFormatter.format("1.00", "AED", html: true) |> Phoenix.HTML.safe_to_string()
+  end
 end


### PR DESCRIPTION
- flatten lists to a format which latest `Phoenix.HTML.safe_to_string/1` can accept (`{:safe, iodata}`)
- update README
- minor version bump to indicate breaking change with older versions
  of phoenix_html